### PR TITLE
fix(data): cleanup data

### DIFF
--- a/data/allocation-tables/ca/allocations.txt
+++ b/data/allocation-tables/ca/allocations.txt
@@ -1,4 +1,4 @@
-Region	Sub-table	lower_frequency	upper_frequency	Category	Service	Footnotes
+region	sub-table	lower_frequency	upper_frequency	category	service	footnotes
 ca		0	8300		-	C1,C2
 ca		0	8300		(not allocated)	
 ca		8300	9000	p	Meteorological Aids	5.54A

--- a/data/allocation-tables/gb/allocations.txt
+++ b/data/allocation-tables/gb/allocations.txt
@@ -1,4 +1,4 @@
-Region	Sub-table	Start Frequency	End Frequency	Category	Service	Footnotes
+region	sub-table	lower_frequency	upper_frequency	category	service	footnotes
 gb		10	8300	s	Not Allocated	5.53, 5.54
 gb		8300	9000	p	Meteorological Aids	UK1, UK43, 5.A116
 gb		9000	11300	p	Radionavigation	UK1, UK11, UK43, EU1

--- a/data/allocation-tables/itu1/allocations.txt
+++ b/data/allocation-tables/itu1/allocations.txt
@@ -1,4 +1,4 @@
-Region	Sub-table	lower_frequency	upper_frequency	Category	Service	Footnotes
+region	sub-table	lower_frequency	upper_frequency	category	service	footnotes
 ITU Region 1		0	9000		-	5.53,5.54
 ITU Region 1		9000	14000	p	Radionavigation	
 ITU Region 1		14000	19950		-	5.55,5.56

--- a/data/allocation-tables/itu2/allocations.txt
+++ b/data/allocation-tables/itu2/allocations.txt
@@ -1,4 +1,4 @@
-Region	Sub-table	lower_frequency	upper_frequency	Category	Service	Footnotes
+region	sub-table	lower_frequency	upper_frequency	category	service	footnotes
 ITU Region 2		0	9000		-	5.53,5.54
 ITU Region 2		9000	14000	p	Radionavigation	
 ITU Region 2		14000	19950		-	5.55,5.56

--- a/data/allocation-tables/itu3/allocations.txt
+++ b/data/allocation-tables/itu3/allocations.txt
@@ -1,4 +1,4 @@
-Region	Sub-table	lower_frequency	upper_frequency	Category	Service	Footnotes
+region	sub-table	lower_frequency	upper_frequency	category	service	footnotes
 itu3		0	9000		-	5.53,5.54
 itu3		9000	14000	p	Radionavigation	
 itu3		14000	19950		-	5.55,5.56

--- a/data/allocation-tables/us/allocations.txt
+++ b/data/allocation-tables/us/allocations.txt
@@ -1,4 +1,4 @@
-Region	Activity	lower_frequency	upper_frequency	Category	Service	Footnotes
+region	activity	lower_frequency	upper_frequency	category	service	footnotes
 US	Federal Government	0	9000		-	5.53,5.54
 US	Federal Government	9000	14000		-	US2
 US	Federal Government	9000	14000	p	Radionavigation	US18
@@ -1002,7 +1002,7 @@ US	Federal Government	50200000000	50400000000	p	Earth Exploration-Satellite (pas
 US	Federal Government	50200000000	50400000000	p	Space Research (passive)	
 US	Federal Government	50400000000	51400000000	p	Fixed	
 US	Federal Government	50400000000	51400000000	p	Fixed-Satellite (Earth-to-space)	
-US	Federal Government	50400000000	51400000000		-	G117	
+US	Federal Government	50400000000	51400000000		-	G117
 US	Federal Government	50400000000	51400000000	p	Mobile	
 US	Federal Government	50400000000	51400000000	p	Mobile-Satellite (Earth-to-space)	
 US	Federal Government	51400000000	52600000000	p	Fixed	
@@ -1354,7 +1354,7 @@ US	Non-Federal-Government	525000	535000		-	US239
 US	Non-Federal-Government	525000	535000	p	Aeronautical Radionavigation (radiobeacons) 	US18
 US	Non-Federal-Government	525000	535000	p	Mobile	US221
 US	Non-Federal-Government	535000	1605000	p	Broadcasting	
-US	Non-Federal-Government	535000	1605000		-	NG1 NG5	
+US	Non-Federal-Government	535000	1605000		-	NG1 NG5
 US	Non-Federal-Government	1605000	1705000		-	US299,NG1,NG5
 US	Non-Federal-Government	1605000	1705000	p	Broadcasting	5.89
 US	Non-Federal-Government	1705000	1800000		-	US240
@@ -1724,10 +1724,10 @@ US	Non-Federal-Government	154000000	156247500	p	Fixed
 US	Non-Federal-Government	154000000	156247500	p	Land Mobile	NG112
 US	Non-Federal-Government	156247500	156762500		-	US77,US266,NG124
 US	Non-Federal-Government	156247500	156762500	p	Maritime Mobile	US106,US226,NG117
-US	Non-Federal-Government	156762500	156837500		-	5.226,US266	
+US	Non-Federal-Government	156762500	156837500		-	5.226,US266
 US	Non-Federal-Government	156762500	156837500	p	Maritime Mobile (distress, urgency, safety, and calling)	
-US	Non-Federal-Government	156837500	157037500		-	5.226,US77,US266	
-US	Non-Federal-Government	156837500	157037500	p	Maritime Mobile		
+US	Non-Federal-Government	156837500	157037500		-	5.226,US77,US266
+US	Non-Federal-Government	156837500	157037500	p	Maritime Mobile	
 US	Non-Federal-Government	157037500	157187500		-	5.226,US214,US266
 US	Non-Federal-Government	157187500	157450000		-	5.226,NG111
 US	Non-Federal-Government	157187500	157450000	p	Mobile except aeronautical mobile	US266
@@ -1830,7 +1830,7 @@ US	Non-Federal-Government	793000000	805000000	p	Mobile
 US	Non-Federal-Government	805000000	806000000	p	Broadcasting	
 US	Non-Federal-Government	805000000	806000000	p	Fixed	
 US	Non-Federal-Government	805000000	806000000	p	Mobile	
-US	Non-Federal-Government	805000000	806000000		-	NG159	
+US	Non-Federal-Government	805000000	806000000		-	NG159
 US	Non-Federal-Government	854000000	894000000		-	US116,US268
 US	Non-Federal-Government	854000000	894000000	p	Fixed	
 US	Non-Federal-Government	854000000	894000000	p	Land Mobile	

--- a/data/allocation-tables/us/government/allocations.txt
+++ b/data/allocation-tables/us/government/allocations.txt
@@ -1,4 +1,4 @@
-Region	Sub-table	Start Frequency	End Frequency	Service	Footnotes
+region	sub-table	lower_frequency	upper_frequency	service	footnotes
 US	Federal Government	0	9000	-	5.53  5.54
 US	Federal Government	9000	14000	-	US2
 US	Federal Government	9000	14000	RADIONAVIGATION	US18

--- a/data/allocation-tables/us/non-government/allocations.txt
+++ b/data/allocation-tables/us/non-government/allocations.txt
@@ -1,4 +1,4 @@
-Region	Sub-table	Start Frequency	End Frequency	Service	Footnotes
+region	sub-table	lower_frequency	upper_frequency	service	footnotes
 US	Non-Federal-Government	0	9000	-	5.53  5.54
 US	Non-Federal-Government	9000	14000	-	US2
 US	Non-Federal-Government	9000	14000	RADIONAVIGATION	US18


### PR DESCRIPTION
# Description
Went through the data. Needed to make some small changes in order to be able to read the data consistently.

Changes:
- lowercase column names
- change "Start Frequency" to "lower_frequency"
- change "End Frequency" to "upper_frequency"
- remove some tabs at the end of some lines for the us data (not sure why we had an extra tab)

Open questions:
- some tables have a category column while some don't. is this optional or should we enforce a category among all columns?
- the US data has an additional "activity" column and is missing a "sub-table" column. what is the difference between these two
- the tab actually makes it harder for a contributor to see unless the editor used is set to show them (such as `:set list` in vim). This is because they will be indistinguishable from spaces. It makes it hard to determine when one needs to be added. I suggest that we convert them to commas, which is an unambiguous delimiter.